### PR TITLE
Upgrade NUnit, dotnet test sdk, and coverlet.collector

### DIFF
--- a/test/CodeQLToolkit.Core.Tests/CodeQLToolkit.Core.Tests/CodeQLToolkit.Core.Tests.csproj
+++ b/test/CodeQLToolkit.Core.Tests/CodeQLToolkit.Core.Tests/CodeQLToolkit.Core.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.0.1" />
+    <PackageReference Include="NUnit.Console" Version="3.17.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.1" />
   </ItemGroup>
 

--- a/test/CodeQLToolkit.Core.Tests/CodeQLToolkit.Core.Tests/CodeQLToolkit.Core.Tests.csproj
+++ b/test/CodeQLToolkit.Core.Tests/CodeQLToolkit.Core.Tests/CodeQLToolkit.Core.Tests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
For better TDD experience, this PR upgrades these packages:
```
<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
<PackageReference Include="NUnit" Version="4.1.0" />
<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
<PackageReference Include="NUnit.Analyzers" Version="4.0.1" />
<PackageReference Include="coverlet.collector" Version="6.0.1" />
```
and adds this package:
```
<PackageReference Include="NUnit.Console" Version="3.17.0" />
```