### PR TITLE
Add support for multi-platform bundle generation and additional files/certs

### DIFF
--- a/.github/actions/install-qlt-local/action.yml
+++ b/.github/actions/install-qlt-local/action.yml
@@ -60,7 +60,7 @@ runs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-linux64.yml
+++ b/.github/workflows/internal-build-release-linux64.yml
@@ -50,7 +50,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-macos64.yml
+++ b/.github/workflows/internal-build-release-macos64.yml
@@ -48,7 +48,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/macos-arm64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/macos-arm64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-win64.yml
+++ b/.github/workflows/internal-build-release-win64.yml
@@ -45,7 +45,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        .\scripts\build_codeql_bundle_dist.ps1 -Version 0.2.0 -WorkDirectory dist -DestinationDirectory .\src\CodeQLToolkit.Core\bin\Release\net6.0\publish\windows-x64\tools\
+        .\scripts\build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory .\src\CodeQLToolkit.Core\bin\Release\net6.0\publish\windows-x64\tools\
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-pr-bundle-integration-test-cpp.yml
+++ b/.github/workflows/internal-pr-bundle-integration-test-cpp.yml
@@ -92,13 +92,16 @@ jobs:
           ${{ steps.analysis.outputs.sarif-output }}/*.sarif
         if-no-files-found: error
 
-    - name: Upload Bundle Used
+    - name: Upload Bundles
       uses: actions/upload-artifact@v2
       with:
-        name: codeql-bundle.tar.gz
+        name: codeql-bundles
         path: |
-          ${{ env.QLT_CODEQL_BUNDLE_PATH }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_LINUX64 }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_WIN64 }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_OSX64 }}
         if-no-files-found: error
+        compression-level: 0
 
     - name: Validate SARIF Results
       shell: bash

--- a/.github/workflows/run-bundle-integration-tests-cpp.yml
+++ b/.github/workflows/run-bundle-integration-tests-cpp.yml
@@ -52,7 +52,6 @@ jobs:
         fi
 
         # ensure bundle runs 
-
         if ! qlt query run install-packs --use-bundle --base example/  ; then
           echo "Failed to install query packs with tool."
           exit 1
@@ -65,13 +64,16 @@ jobs:
         echo "Checking Bundle Existence"
         ls -l ${{ env.QLT_CODEQL_HOME }}/../out/
 
-    - name: Upload Bundle Used
+    - name: Upload Bundles
       uses: actions/upload-artifact@v2
       with:
-        name: codeql-bundle.tar.gz
+        name: codeql-bundles
         path: |
-          ${{ env.QLT_CODEQL_BUNDLE_PATH }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_LINUX64 }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_WIN64 }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_OSX64 }}
         if-no-files-found: error
+        compression-level: 0
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -15,7 +15,7 @@ Note that we keep recent copies of tools (for local debugging purposes) in the `
 **CodeQL Bundle**
 
 ```
-./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Debug/net6.0/tools
+./scripts/build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Debug/net6.0/tools
 ```
 
 

--- a/scripts/build_codeql_bundle_dist.ps1
+++ b/scripts/build_codeql_bundle_dist.ps1
@@ -1,12 +1,12 @@
 param(
-    [Parameter(Mandatory=$true)] 
+    [Parameter(Mandatory = $true)] 
     [string]
     $Version,
-    [Parameter(Mandatory=$true)] 
+    [Parameter(Mandatory = $true)] 
     [string]
     $WorkDirectory,      
 
-    [Parameter(Mandatory=$true)] 
+    [Parameter(Mandatory = $true)] 
     [string]
     $DestinationDirectory       
 )
@@ -20,7 +20,7 @@ if (-not (Test-Path $DestinationDirectory)) {
 }
 
 # download a copy of the release from GitHub
-gh release download "v$Version" --repo https://github.com/jsinglet/codeql-bundle  -D $WorkDirectory -A zip
+gh release download "v$Version" --repo https://github.com/kraiouchkine/codeql-bundle  -D $WorkDirectory -A zip
 
 # extract the zip file
 Expand-Archive -Path "$WorkDirectory\codeql-bundle-$Version.zip" -DestinationPath $WorkDirectory
@@ -45,9 +45,10 @@ pyinstaller -F -n codeql_bundle cli.py
 Pop-Location 
 Pop-Location 
 
-if($IsWindows){
+if ($IsWindows) {
     $OutputFile = Join-Path $ArchiveDirectory "codeql_bundle" "dist" "codeql_bundle.exe"
-}else{
+}
+else {
     $OutputFile = Join-Path $ArchiveDirectory "codeql_bundle" "dist" "codeql_bundle"
 }
 

--- a/src/CodeQLToolkit.Features/Bundle/BundleFeatureMain.cs
+++ b/src/CodeQLToolkit.Features/Bundle/BundleFeatureMain.cs
@@ -29,7 +29,7 @@ namespace CodeQLToolkit.Features.Bundle
             commandFeature = new BundleCommandFeature();
             lifecycleFeature = new BundleLifecycleFeature();
         }
-        public static BundleFeatureMain Instance { get { return instance; } }
+        public static BundleFeatureMain Instance => instance;
 
         public void Register(Command parentCommand)
         {

--- a/src/CodeQLToolkit.Features/Bundle/Commands/BundleCommandFeature.cs
+++ b/src/CodeQLToolkit.Features/Bundle/Commands/BundleCommandFeature.cs
@@ -11,9 +11,7 @@ namespace CodeQLToolkit.Features.Bundle.Commands
 {
     public class BundleCommandFeature : FeatureBase, IToolkitLifecycleFeature
     {
-        public override LanguageType[] SupportedLangauges
-        {
-            get => new LanguageType[] {
+        public override LanguageType[] SupportedLangauges => new LanguageType[] {
             LanguageType.C,
             LanguageType.CPP,
             LanguageType.CSHARP,
@@ -23,7 +21,6 @@ namespace CodeQLToolkit.Features.Bundle.Commands
             LanguageType.RUBY,
             LanguageType.PYTHON
         };
-        }
 
         public BundleCommandFeature()
         {
@@ -62,7 +59,7 @@ namespace CodeQLToolkit.Features.Bundle.Commands
 
                 }.Run();
 
-            },Globals.BasePathOption, expectedOption, actualOption);
+            }, Globals.BasePathOption, expectedOption, actualOption);
         }
 
         public int Run()

--- a/src/CodeQLToolkit.Features/Bundle/Lifecycle/BundleLifecycleFeature.cs
+++ b/src/CodeQLToolkit.Features/Bundle/Lifecycle/BundleLifecycleFeature.cs
@@ -7,14 +7,12 @@ namespace CodeQLToolkit.Features.Bundle.Lifecycle
 {
     public class BundleLifecycleFeature : FeatureBase, IToolkitLifecycleFeature
     {
-        public BundleLifecycleFeature() 
+        public BundleLifecycleFeature()
         {
             FeatureName = "Bundle";
         }
 
-        public override LanguageType[] SupportedLangauges
-        {
-            get => new LanguageType[] {
+        public override LanguageType[] SupportedLangauges => new LanguageType[] {
             LanguageType.C,
             LanguageType.CPP,
             LanguageType.CSHARP,
@@ -24,7 +22,6 @@ namespace CodeQLToolkit.Features.Bundle.Lifecycle
             LanguageType.RUBY,
             LanguageType.PYTHON
         };
-        }
 
         public void Register(Command parentCommand)
         {
@@ -44,7 +41,7 @@ namespace CodeQLToolkit.Features.Bundle.Lifecycle
             var setCommand = new Command("set", "Functions pertaining to setting variables related to custom CodeQL bundles.");
             //parentCommand.Add(setCommand);
 
-            var enableCommand = new Command("enable-custom-bundles", "Enables custom CodeQL Bundles.");            
+            var enableCommand = new Command("enable-custom-bundles", "Enables custom CodeQL Bundles.");
             //setCommand.Add(enableCommand);
 
             var disableCommand = new Command("disable-custom-bundles", "Disables custom CodeQL Bundles.");

--- a/src/CodeQLToolkit.Features/CodeQL/CodeQLFeatureMain.cs
+++ b/src/CodeQLToolkit.Features/CodeQL/CodeQLFeatureMain.cs
@@ -7,7 +7,7 @@ using CodeQLToolkit.Features.CodeQL.Commands;
 
 namespace CodeQLToolkit.Features.CodeQL
 {
-        public class CodeQLFeatureMain : IToolkitFeature
+    public class CodeQLFeatureMain : IToolkitFeature
     {
         readonly CodeQLLifecycleFeature lifecycleFeature;
         readonly CodeQLCommandFeature commandFeature;
@@ -24,7 +24,7 @@ namespace CodeQLToolkit.Features.CodeQL
             commandFeature = new CodeQLCommandFeature();
         }
 
-        public static CodeQLFeatureMain Instance { get { return instance; } }
+        public static CodeQLFeatureMain Instance => instance;
 
         public int Run()
         {
@@ -36,7 +36,7 @@ namespace CodeQLToolkit.Features.CodeQL
         {
             var queryCommand = new Command("codeql", "Use the features related to managing the version of CodeQL used by this repository.");
             parentCommand.Add(queryCommand);
-            
+
             Log<CodeQLFeatureMain>.G().LogInformation("Registering scaffolding submodule.");
             lifecycleFeature.Register(queryCommand);
 

--- a/src/CodeQLToolkit.Features/CodeQL/Commands/CodeQLCommandFeature.cs
+++ b/src/CodeQLToolkit.Features/CodeQL/Commands/CodeQLCommandFeature.cs
@@ -15,7 +15,7 @@ namespace CodeQLToolkit.Features.CodeQL.Commands
 {
     public class CodeQLCommandFeature : FeatureBase, IToolkitLifecycleFeature
     {
-        public override LanguageType[] SupportedLangauges { get => new LanguageType[] { 
+        public override LanguageType[] SupportedLangauges => new LanguageType[] {
             LanguageType.C,
             LanguageType.CPP,
             LanguageType.CSHARP,
@@ -23,8 +23,8 @@ namespace CodeQLToolkit.Features.CodeQL.Commands
             LanguageType.JAVASCRIPT,
             LanguageType.GO,
             LanguageType.RUBY,
-            LanguageType.PYTHON            
-        }; }
+            LanguageType.PYTHON
+        };
 
         public CodeQLCommandFeature()
         {
@@ -37,10 +37,10 @@ namespace CodeQLToolkit.Features.CodeQL.Commands
 
             var runCommand = new Command("run", "Functions pertaining to running codeql-related commands.");
             parentCommand.Add(runCommand);
-            
+
             var installCommand = new Command("install", "Installs CodeQL (bundle or release distribution) locally.");
-            var customBundleOption = new Option<bool>("--custom-bundle", () => false, "Build a custom bundle and compile the bundle.") { IsRequired = true};
-            var quickBundleOption = new Option<bool>("--quick-bundle", () => false,  "Build a custom bundle and DO NOT compile the bundle.") { IsRequired = true};
+            var customBundleOption = new Option<bool>("--custom-bundle", () => false, "Build a custom bundle and compile the bundle.") { IsRequired = true };
+            var quickBundleOption = new Option<bool>("--quick-bundle", () => false, "Build a custom bundle and DO NOT compile the bundle.") { IsRequired = true };
             var packsOption = new Option<string[]>("--packs", "When creating bundles, this specifies the packs to include, Example `pack1 pack2 pack3`. You may specify also as `--pack pack1 --pack2 --pack3`") { IsRequired = false, AllowMultipleArgumentsPerToken = true };
 
             installCommand.Add(customBundleOption);
@@ -48,7 +48,7 @@ namespace CodeQLToolkit.Features.CodeQL.Commands
             installCommand.Add(packsOption);
 
             runCommand.Add(installCommand);
-            
+
             installCommand.SetHandler((basePath, automationType, customBundleOption, quickBundleOption, packs) =>
             {
                 Log<CodeQLCommandFeature>.G().LogInformation("Executing install command...");

--- a/src/CodeQLToolkit.Features/CodeQL/Commands/Targets/InstallCommand.cs
+++ b/src/CodeQLToolkit.Features/CodeQL/Commands/Targets/InstallCommand.cs
@@ -15,16 +15,45 @@ namespace CodeQLToolkit.Features.CodeQL.Commands.Targets
         public bool CustomBundles { get; set; }
         public bool QuickBundles { get; set; }
         public string[] Packs { get; set; }
+
+        void SetEnvironmentVariableMultiTarget(string name, string value)
+        {
+            Log<InstallCommand>.G().LogInformation($"Setting {name} to {value}...");
+
+            Environment.SetEnvironmentVariable(name, value);
+
+            if (AutomationTypeHelper.AutomationTypeFromString(AutomationTarget) == AutomationType.ACTIONS)
+            {
+                string? githubEnvPath = Environment.GetEnvironmentVariable("GITHUB_ENV");
+                try
+                {
+                    if (File.Exists(githubEnvPath))
+                    {
+                        File.AppendAllText(githubEnvPath, $"{name}={value}\n");
+                    }
+                    else
+                    {
+                        throw new Exception("Could not find GITHUB_ENV file.");
+                    }
+                }
+                catch (Exception)
+                {
+                    Log<InstallCommand>.G().LogError($"Could not write to GITHUB_ENV file.");
+                    throw;
+                }
+            }
+        }
+
         public override void Run()
         {
             Log<InstallCommand>.G().LogInformation($"Running Install command");
 
             // First, check if CodeQL is installed.
             var installation = CodeQLInstallation.LoadFromConfig(Base);
-            if(CustomBundles || QuickBundles)
+            if (CustomBundles || QuickBundles)
             {
                 installation.EnableCustomCodeQLBundles = true;
-                if (Packs!=null && Packs.Length > 0)
+                if (Packs != null && Packs.Length > 0)
                 {
                     Log<InstallCommand>.G().LogInformation($"Overriding Packs on the command line. The following Packs will be packaged:");
                     installation.CodeQLPackConfiguration = Packs.Select(p => new CodeQLPackConfiguration()
@@ -40,14 +69,12 @@ namespace CodeQLToolkit.Features.CodeQL.Commands.Targets
 
                 installation.LogPacksToBeBuilt();
 
-
                 installation.QuickBundle = QuickBundles;
             }
 
             Log<InstallCommand>.G().LogInformation($"Checking for installation...");
 
-            // if it is the case that it is installed but we are in custom bundle mode we RE install it. 
-
+            // If CodeQL is already installed, but custom bundles are enabled, reinstall CodeQL anyway to ensure use of the correct custom bundle.
             if (installation.IsInstalled() && !installation.EnableCustomCodeQLBundles)
             {
                 Log<InstallCommand>.G().LogInformation($"CodeQL is already installed at that version. Please delete the installation directory to reinstall.");
@@ -57,39 +84,19 @@ namespace CodeQLToolkit.Features.CodeQL.Commands.Targets
                 Log<InstallCommand>.G().LogInformation($"Installing CodeQL...");
                 installation.Install();
 
-                // set the environment variable
-                Log<InstallCommand>.G().LogInformation($"Setting QLT_CODEQL_HOME to {installation.CodeQLHome}...");
-                Log<InstallCommand>.G().LogInformation($"Setting QLT_CODEQL_PATH to {installation.CodeQLToolBinary}...");
+                SetEnvironmentVariableMultiTarget("QLT_CODEQL_HOME", installation.CodeQLHome);
+                SetEnvironmentVariableMultiTarget("QLT_CODEQL_PATH", installation.CodeQLToolBinary);
 
-                Environment.SetEnvironmentVariable("QLT_CODEQL_HOME", installation.CodeQLHome);
-                Environment.SetEnvironmentVariable("QLT_CODEQL_PATH", installation.CodeQLToolBinary);
                 if (CustomBundles || QuickBundles)
                 {
-                    Environment.SetEnvironmentVariable("QLT_CODEQL_BUNDLE_PATH", installation.CustomBundleOutputBundle);
+                    SetEnvironmentVariableMultiTarget("QLT_CODEQL_BUNDLE_PATH", installation.CustomBundleOutputBundleCurrentPlatform);
+                    SetEnvironmentVariableMultiTarget("QLT_CODEQL_BUNDLE_PATH_WIN64", installation.CustomBundleOutputBundleWindows);
+                    SetEnvironmentVariableMultiTarget("QLT_CODEQL_BUNDLE_PATH_OSX64", installation.CustomBundleOutputBundleOSX);
+                    SetEnvironmentVariableMultiTarget("QLT_CODEQL_BUNDLE_PATH_LINUX64", installation.CustomBundleOutputBundleLinux);
                 }
-
-                if (AutomationTypeHelper.AutomationTypeFromString(AutomationTarget) == AutomationType.ACTIONS)
-                {
-                    if (Environment.GetEnvironmentVariable("GITHUB_ENV") != null && File.Exists(Environment.GetEnvironmentVariable("GITHUB_ENV")))
-                    {
-                        
-                        File.AppendAllText(Environment.GetEnvironmentVariable("GITHUB_ENV"), $"QLT_CODEQL_HOME={installation.CodeQLHome}" + "\n");
-                        File.AppendAllText(Environment.GetEnvironmentVariable("GITHUB_ENV"), $"QLT_CODEQL_PATH={installation.CodeQLToolBinary}" + "\n");
-                        if (CustomBundles || QuickBundles)
-                        {
-                            File.AppendAllText(Environment.GetEnvironmentVariable("GITHUB_ENV"), $"QLT_CODEQL_BUNDLE_PATH={installation.CustomBundleOutputBundle}" + "\n");
-                        }
-                    }
-                }
-
             }
 
-
             Log<InstallCommand>.G().LogInformation($"Done.");
-
-
-
-
         }
     }
 }

--- a/src/CodeQLToolkit.Features/CodeQL/Lifecycle/Targets/GetVersionLifecycleTarget.cs
+++ b/src/CodeQLToolkit.Features/CodeQL/Lifecycle/Targets/GetVersionLifecycleTarget.cs
@@ -9,7 +9,7 @@ namespace CodeQLToolkit.Features.CodeQL.Lifecycle.Targets
 {
     public class GetVersionLifecycleTarget : ILifecycleTarget
     {
-       
+
         override public void Run()
         {
             Log<GetVersionLifecycleTarget>.G().LogInformation("Running get command...");
@@ -19,11 +19,11 @@ namespace CodeQLToolkit.Features.CodeQL.Lifecycle.Targets
                 Base = Base
             };
 
-            if (!File.Exists(c.CodeQLConfigFilePath))
+            if (!File.Exists(c.QLTConfigFilePath))
             {
-                ProcessUtils.DieWithError($"Cannot read values from missing file {c.CodeQLConfigFilePath}");
+                ProcessUtils.DieWithError($"Cannot read values from missing file {c.QLTConfigFilePath}");
             }
-           
+
             var config = c.FromFile();
 
             // This should be updated so that we can pretty print all the various options:

--- a/src/CodeQLToolkit.Features/Pack/Commands/Targets/HelloJeongsooCommandTarget.cs
+++ b/src/CodeQLToolkit.Features/Pack/Commands/Targets/HelloJeongsooCommandTarget.cs
@@ -15,7 +15,8 @@ namespace CodeQLToolkit.Features.Pack.Commands.Targets
 
         public override void Run()
         {
-            for(int i = 0; i < Times; i++) { 
+            for (int i = 0; i < Times; i++)
+            {
                 Console.WriteLine($"Hello! My Base Target is: {Base}");
             }
 
@@ -25,9 +26,9 @@ namespace CodeQLToolkit.Features.Pack.Commands.Targets
                 Base = Base
             };
 
-            if (!File.Exists(c.CodeQLConfigFilePath))
+            if (!File.Exists(c.QLTConfigFilePath))
             {
-                ProcessUtils.DieWithError($"Cannot read values from missing file {c.CodeQLConfigFilePath}");
+                ProcessUtils.DieWithError($"Cannot read values from missing file {c.QLTConfigFilePath}");
             }
 
             var config = c.FromFile();

--- a/src/CodeQLToolkit.Features/Pack/PackFeatureMain.cs
+++ b/src/CodeQLToolkit.Features/Pack/PackFeatureMain.cs
@@ -23,7 +23,7 @@ namespace CodeQLToolkit.Features.Pack
         {
             commandFeature = new PackCommandFeature();
         }
-        public static PackFeatureMain Instance { get { return instance; } }
+        public static PackFeatureMain Instance => instance;
 
         public void Register(Command parentCommand)
         {

--- a/src/CodeQLToolkit.Features/Query/QueryFeatureMain.cs
+++ b/src/CodeQLToolkit.Features/Query/QueryFeatureMain.cs
@@ -18,7 +18,8 @@ namespace CodeQLDevelopmentLifecycleToolkit.Features.Query
 
         readonly static QueryFeatureMain instance;
 
-        static QueryFeatureMain() { 
+        static QueryFeatureMain()
+        {
             instance = new QueryFeatureMain();
         }
         private QueryFeatureMain()
@@ -28,7 +29,7 @@ namespace CodeQLDevelopmentLifecycleToolkit.Features.Query
             lifecycleFeature = new QueryLifecycleFeature();
         }
 
-        public static QueryFeatureMain Instance { get { return instance; } }
+        public static QueryFeatureMain Instance => instance;
 
         public int Run()
         {
@@ -46,7 +47,7 @@ namespace CodeQLDevelopmentLifecycleToolkit.Features.Query
             scaffoldFeature.Register(queryCommand);
             commandFeature.Register(queryCommand);
             lifecycleFeature.Register(queryCommand);
-            
+
         }
     }
 }

--- a/src/CodeQLToolkit.Features/Query/Scaffolding/QueryScaffoldFeature.cs
+++ b/src/CodeQLToolkit.Features/Query/Scaffolding/QueryScaffoldFeature.cs
@@ -6,12 +6,13 @@ using System.CommandLine;
 
 namespace CodeQLToolkit.Features.Query.Scaffolding
 {
-    public class QueryScaffoldFeature : FeatureBase, IToolkitScaffoldingFeature 
+    public class QueryScaffoldFeature : FeatureBase, IToolkitScaffoldingFeature
     {
-        public QueryScaffoldFeature() {
+        public QueryScaffoldFeature()
+        {
             FeatureName = "Query";
         }
-        public override LanguageType[] SupportedLangauges { get => new LanguageType[] { LanguageType.C, LanguageType.CPP, LanguageType.JAVASCRIPT}; }
+        public override LanguageType[] SupportedLangauges => new LanguageType[] { LanguageType.C, LanguageType.CPP, LanguageType.JAVASCRIPT };
 
         public void Register(Command parentCommand)
         {
@@ -26,9 +27,9 @@ namespace CodeQLToolkit.Features.Query.Scaffolding
             var createQueryPackOption = new Option<bool>("--create-query-pack", () => true, "Create a new query pack if none exists.");
             var overwriteExistingOption = new Option<bool>("--overwrite-existing", () => false, "Overwrite exiting files (if they exist).");
 
-            var createTestsOption = new Option<bool>("--create-tests", ()=> true, "Create a new unit test for this query if it doesn't already exist.");
+            var createTestsOption = new Option<bool>("--create-tests", () => true, "Create a new unit test for this query if it doesn't already exist.");
             var queryNameOption = new Option<string>("--query-name", "Name of the query. Note: Do not specify the `.ql` extension in naming your query.") { IsRequired = true };
-            var queryLanguageOption = new Option<string>("--language", $"The language to generate a query for.") { IsRequired = true}
+            var queryLanguageOption = new Option<string>("--language", $"The language to generate a query for.") { IsRequired = true }
             .FromAmong(SupportedLangauges.Select(x => x.ToOptionString()).ToArray());
             var queryPackOption = new Option<string>("--pack", "The name of the query pack to place this query in.") { IsRequired = true };
             var queryPackScopeOption = new Option<string>("--scope", "The scope to use") { IsRequired = true };
@@ -62,8 +63,8 @@ namespace CodeQLToolkit.Features.Query.Scaffolding
                         CreateTests = createTests,
                         CreateQueryPack = createQueryPack,
                         OverwriteExisting = overwriteExisting,
-                        FeatureName = FeatureName 
-                    }.Run(); 
+                        FeatureName = FeatureName
+                    }.Run();
 
                 }, createQueryPackOption, createTestsOption, queryNameOption, queryLanguageOption, queryPackOption, Globals.BasePathOption, overwriteExistingOption, queryPackScopeOption);
             }

--- a/src/CodeQLToolkit.Features/Templates/Bundle/Actions/run-bundle-integration-tests.liquid
+++ b/src/CodeQLToolkit.Features/Templates/Bundle/Actions/run-bundle-integration-tests.liquid
@@ -59,7 +59,6 @@ jobs:
         fi
 
         # ensure bundle runs 
-
         if ! qlt query run install-packs --use-bundle --base example/  ; then
           echo "Failed to install query packs with tool."
           exit 1
@@ -74,7 +73,6 @@ jobs:
         fi
 
         # ensure bundle runs 
-
         if ! qlt query run install-packs --use-bundle  ; then
           echo "Failed to install query packs with tool."
           exit 1
@@ -87,13 +85,16 @@ jobs:
         echo "Checking Bundle Existence"
         ls -l ${{ env.QLT_CODEQL_HOME }}/../out/
 
-    - name: Upload Bundle Used
+    - name: Upload Bundles
       uses: actions/upload-artifact@v2
       with:
-        name: codeql-bundle.tar.gz
+        name: codeql-bundles
         path: |
-          ${{ env.QLT_CODEQL_BUNDLE_PATH }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_LINUX64 }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_WIN64 }}
+          ${{ env.QLT_CODEQL_BUNDLE_PATH_OSX64 }}
         if-no-files-found: error
+        compression-level: 0
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/src/CodeQLToolkit.Features/Test/Commands/Targets/Actions/GetMatrixCommandTarget.cs
+++ b/src/CodeQLToolkit.Features/Test/Commands/Targets/Actions/GetMatrixCommandTarget.cs
@@ -30,16 +30,16 @@ namespace CodeQLToolkit.Features.Test.Commands.Targets.Actions
                 Base = Base
             };
 
-            if (!File.Exists(c.CodeQLConfigFilePath))
+            if (!File.Exists(c.QLTConfigFilePath))
             {
-                ProcessUtils.DieWithError($"Cannot read values from missing file {c.CodeQLConfigFilePath}");
+                ProcessUtils.DieWithError($"Cannot read values from missing file {c.QLTConfigFilePath}");
             }
 
             var config = c.FromFile();
 
             List<object> configs = new List<object>();
 
-            foreach(var os in OSVersions)
+            foreach (var os in OSVersions)
             {
                 Log<TestCommandFeature>.G().LogInformation($"Creating matrix for {os}");
 
@@ -66,7 +66,7 @@ namespace CodeQLToolkit.Features.Test.Commands.Targets.Actions
 
             Log<TestCommandFeature>.G().LogInformation($"Writing matrix output {matrixVariable} to {envFile}");
 
-            File.AppendAllText(envFile, matrixVariable );
+            File.AppendAllText(envFile, matrixVariable);
 
             Log<TestCommandFeature>.G().LogInformation($"Done.");
 

--- a/src/CodeQLToolkit.Features/Test/Commands/TestCommandFeature.cs
+++ b/src/CodeQLToolkit.Features/Test/Commands/TestCommandFeature.cs
@@ -14,7 +14,7 @@ namespace CodeQLToolkit.Features.Test.Commands
 {
     public class TestCommandFeature : FeatureBase, IToolkitLifecycleFeature
     {
-        public override LanguageType[] SupportedLangauges { get => new LanguageType[] { 
+        public override LanguageType[] SupportedLangauges => new LanguageType[] {
             LanguageType.C,
             LanguageType.CPP,
             LanguageType.CSHARP,
@@ -22,8 +22,8 @@ namespace CodeQLToolkit.Features.Test.Commands
             LanguageType.JAVASCRIPT,
             LanguageType.GO,
             LanguageType.RUBY,
-            LanguageType.PYTHON            
-        }; }
+            LanguageType.PYTHON
+        };
 
         public TestCommandFeature()
         {
@@ -46,7 +46,7 @@ namespace CodeQLToolkit.Features.Test.Commands
 
             // a command that runs the actual tests 
             var unitTestsCommand = new Command("execute-unit-tests", "Runs unit tests within a repository based on the current configuration.");
-            
+
             var numThreadsOption = new Option<int>("--num-threads", () => 4, "The number of threads to use for runner. For best performance, do not exceed the number of physical cores on your system.") { IsRequired = true };
             var workDirectoryOption = new Option<string>("--work-dir", () => Path.GetTempPath(), "Where to place intermediate execution output files.") { IsRequired = true };
             var languageOption = new Option<string>("--language", $"The language to run tests for.") { IsRequired = true }.FromAmong(SupportedLangauges.Select(x => x.ToOptionString()).ToArray());
@@ -55,7 +55,7 @@ namespace CodeQLToolkit.Features.Test.Commands
             //var stdLibIdentOption = new Option<string>("--stdlib-ident", $"A string identifying the standard library used.") { IsRequired = true };
             var extraCodeQLOptions = new Option<string>("--codeql-args", $"Extra arguments to pass to CodeQL.") { IsRequired = false };
 
-            unitTestsCommand.Add(numThreadsOption); 
+            unitTestsCommand.Add(numThreadsOption);
             unitTestsCommand.Add(workDirectoryOption);
             unitTestsCommand.Add(languageOption);
             unitTestsCommand.Add(runnerOSOption);
@@ -75,8 +75,9 @@ namespace CodeQLToolkit.Features.Test.Commands
             runCommand.Add(getMatrixTestCommand);
             runCommand.Add(unitTestsCommand);
             runCommand.Add(validateUnitTestsCommand);
-            
-            getMatrixTestCommand.SetHandler((basePath, automationType, osVersions) => {
+
+            getMatrixTestCommand.SetHandler((basePath, automationType, osVersions) =>
+            {
 
                 Log<TestCommandFeature>.G().LogInformation("Executing get-matrix command...");
 
@@ -94,7 +95,8 @@ namespace CodeQLToolkit.Features.Test.Commands
             }, Globals.BasePathOption, Globals.AutomationTypeOption, matrixOSVersion);
 
             //stdLibIdent
-            unitTestsCommand.SetHandler((basePath, automationType, numThreads, workDirectory, language, runnerOS, extraArgs, useBundle) => {
+            unitTestsCommand.SetHandler((basePath, automationType, numThreads, workDirectory, language, runnerOS, extraArgs, useBundle) =>
+            {
 
                 Log<TestCommandFeature>.G().LogInformation("Executing execute-unit-tests command...");
 
@@ -110,9 +112,9 @@ namespace CodeQLToolkit.Features.Test.Commands
                     Base = basePath
                 };
 
-                if (!File.Exists(c.CodeQLConfigFilePath))
+                if (!File.Exists(c.QLTConfigFilePath))
                 {
-                    ProcessUtils.DieWithError($"Cannot read values from missing file {c.CodeQLConfigFilePath}");
+                    ProcessUtils.DieWithError($"Cannot read values from missing file {c.QLTConfigFilePath}");
                 }
 
                 var config = c.FromFile();
@@ -129,12 +131,12 @@ namespace CodeQLToolkit.Features.Test.Commands
 
                 featureTarget.Run();
 
-            }, Globals.BasePathOption, 
-               Globals.AutomationTypeOption, 
+            }, Globals.BasePathOption,
+               Globals.AutomationTypeOption,
                numThreadsOption,
-               workDirectoryOption, 
-               languageOption, 
-               runnerOSOption, 
+               workDirectoryOption,
+               languageOption,
+               runnerOSOption,
                extraCodeQLOptions,
                Globals.UseBundle
             );

--- a/src/CodeQLToolkit.Features/Test/Lifecycle/TestLifecycleFeature.cs
+++ b/src/CodeQLToolkit.Features/Test/Lifecycle/TestLifecycleFeature.cs
@@ -8,14 +8,12 @@ namespace CodeQLToolkit.Features.Test.Lifecycle
 {
     public class TestLifecycleFeature : FeatureBase, IToolkitLifecycleFeature
     {
-        public TestLifecycleFeature() 
+        public TestLifecycleFeature()
         {
             FeatureName = "Test";
         }
 
-        public override LanguageType[] SupportedLangauges
-        {
-            get => new LanguageType[] {
+        public override LanguageType[] SupportedLangauges => new LanguageType[] {
             LanguageType.C,
             LanguageType.CPP,
             LanguageType.CSHARP,
@@ -25,7 +23,6 @@ namespace CodeQLToolkit.Features.Test.Lifecycle
             LanguageType.RUBY,
             LanguageType.PYTHON
         };
-        }
 
         public void Register(Command parentCommand)
         {
@@ -50,7 +47,7 @@ namespace CodeQLToolkit.Features.Test.Lifecycle
             parentCommand.Add(initCommand);
 
 
-            
+
             initCommand.SetHandler((devMode, basePath, automationType, overwriteExisting, numThreads, useRunner, language, branch) =>
             {
                 Log<TestLifecycleFeature>.G().LogInformation("Executing init command...");
@@ -62,14 +59,14 @@ namespace CodeQLToolkit.Features.Test.Lifecycle
 
                 // setup common params 
                 featureTarget.FeatureName = FeatureName;
-                featureTarget.Base = basePath;             
+                featureTarget.Base = basePath;
                 featureTarget.OverwriteExisting = overwriteExisting;
                 featureTarget.NumThreads = numThreads;
-                featureTarget.UseRunner = useRunner;    
+                featureTarget.UseRunner = useRunner;
                 featureTarget.Language = language;
                 //featureTarget.ExtraArgs = extraArgs;
                 featureTarget.DevMode = devMode;
-                featureTarget.Branch = branch; 
+                featureTarget.Branch = branch;
                 featureTarget.Run();
 
             }, Globals.Development, Globals.BasePathOption, Globals.AutomationTypeOption, overwriteExistingOption, numThreadsOption, useRunnerOption, languageOption, branchOption);

--- a/src/CodeQLToolkit.Features/Test/TestFeatureMain.cs
+++ b/src/CodeQLToolkit.Features/Test/TestFeatureMain.cs
@@ -4,7 +4,7 @@ using CodeQLToolkit.Shared.Feature;
 using System.CommandLine;
 
 namespace CodeQLToolkit.Features.Test
-{ 
+{
     public class TestFeatureMain : IToolkitFeature
 
     {
@@ -20,10 +20,10 @@ namespace CodeQLToolkit.Features.Test
         private TestFeatureMain()
         {
             lifecycleFeature = new TestLifecycleFeature();
-            commandFeature = new TestCommandFeature();  
+            commandFeature = new TestCommandFeature();
         }
-        public static TestFeatureMain Instance { get { return instance; } }
-        
+        public static TestFeatureMain Instance => instance;
+
         public void Register(Command parentCommand)
         {
             var testCommand = new Command("test", "Features related to the running and processing of CodeQL Unit Tests.");

--- a/src/CodeQLToolkit.Features/Validation/Commands/ValidationCommandFeature.cs
+++ b/src/CodeQLToolkit.Features/Validation/Commands/ValidationCommandFeature.cs
@@ -6,7 +6,7 @@ namespace CodeQLToolkit.Features.Test.Commands
 {
     public class ValidationCommandFeature : FeatureBase, IToolkitLifecycleFeature
     {
-        public override LanguageType[] SupportedLangauges { get => new LanguageType[] { 
+        public override LanguageType[] SupportedLangauges => new LanguageType[] {
             LanguageType.C,
             LanguageType.CPP,
             LanguageType.CSHARP,
@@ -14,8 +14,8 @@ namespace CodeQLToolkit.Features.Test.Commands
             LanguageType.JAVASCRIPT,
             LanguageType.GO,
             LanguageType.RUBY,
-            LanguageType.PYTHON            
-        }; }
+            LanguageType.PYTHON
+        };
 
         public ValidationCommandFeature()
         {
@@ -49,10 +49,10 @@ namespace CodeQLToolkit.Features.Test.Commands
                 {
                     Base = basePath,
                     Language = language,
-                    PrettyPrint = prettyPrint,              
+                    PrettyPrint = prettyPrint,
                     UseBundle = useBundle
                 }.Run();
-                
+
             }, languageOption, Globals.BasePathOption, prettyPrintOption, Globals.UseBundle);
         }
 

--- a/src/CodeQLToolkit.Features/Validation/Lifecycle/ValidationLifecycleFeature.cs
+++ b/src/CodeQLToolkit.Features/Validation/Lifecycle/ValidationLifecycleFeature.cs
@@ -16,9 +16,7 @@ namespace CodeQLToolkit.Features.Validation.Lifecycle
             FeatureName = "Validation";
         }
 
-        public override LanguageType[] SupportedLangauges
-        {
-            get => new LanguageType[] {
+        public override LanguageType[] SupportedLangauges => new LanguageType[] {
             LanguageType.C,
             LanguageType.CPP,
             LanguageType.CSHARP,
@@ -28,7 +26,6 @@ namespace CodeQLToolkit.Features.Validation.Lifecycle
             LanguageType.RUBY,
             LanguageType.PYTHON
         };
-        }
 
         public void Register(Command parentCommand)
         {
@@ -64,7 +61,7 @@ namespace CodeQLToolkit.Features.Validation.Lifecycle
                 featureTarget.OverwriteExisting = overwriteExisting;
                 featureTarget.Language = language;
                 featureTarget.DevMode = devMode;
-                featureTarget.Branch = branch;  
+                featureTarget.Branch = branch;
                 featureTarget.Run();
 
             }, Globals.Development, Globals.BasePathOption, Globals.AutomationTypeOption, overwriteExistingOption, languageOption, useRunnerOption, branchOption);

--- a/src/CodeQLToolkit.Features/Validation/ValidationFeatureMain.cs
+++ b/src/CodeQLToolkit.Features/Validation/ValidationFeatureMain.cs
@@ -18,15 +18,15 @@ namespace CodeQLToolkit.Features.Validation
 
         private ValidationFeatureMain()
         {
-            commandFeature = new ValidationCommandFeature();  
+            commandFeature = new ValidationCommandFeature();
             validationLifecycleFeature = new ValidationLifecycleFeature();
         }
-        public static ValidationFeatureMain Instance { get { return instance; } }
-        
+        public static ValidationFeatureMain Instance => instance;
+
         public void Register(Command parentCommand)
         {
             var validationCommand = new Command("validation", "Features related to the validation of CodeQL Development Repositories.");
-            parentCommand.Add(validationCommand);            
+            parentCommand.Add(validationCommand);
 
             Log<ValidationFeatureMain>.G().LogInformation("Registering command submodule.");
             commandFeature.Register(validationCommand);

--- a/src/CodeQLToolkit.Shared/CodeQL/InstallationRepository.cs
+++ b/src/CodeQLToolkit.Shared/CodeQL/InstallationRepository.cs
@@ -14,46 +14,23 @@ namespace CodeQLToolkit.Shared.CodeQL
         readonly static string BUNDLE_DIRECTORY = "bundle";
         readonly static string CUSTOM_BUNDLE_DIRECTORY = "custom-bundle";
 
-        public static string GetLocation
-        {
-            get
-            {
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".qlt");
-            }
-        }
+        public static string GetLocation => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".qlt");
 
-        public static string PackageLocation
-        {
-            get
-            {
-                return Path.Combine(GetLocation, PAKCAGE_DIRECTORY);
-            }
-        }
+        public static string PackageLocation => Path.Combine(GetLocation, PAKCAGE_DIRECTORY);
 
-        public static string BundleLocation
-        {
-            get
-            {
-                return Path.Combine(GetLocation, BUNDLE_DIRECTORY);
-            }
-        }
+        public static string BundleLocation => Path.Combine(GetLocation, BUNDLE_DIRECTORY);
 
-        public static string CustomBundleLocation
-        {
-            get
-            {
-                return Path.Combine(GetLocation, CUSTOM_BUNDLE_DIRECTORY);
-            }
-        }
+        public static string CustomBundleLocation => Path.Combine(GetLocation, CUSTOM_BUNDLE_DIRECTORY);
 
 
         public static string DirectoryForVersion(ArtifactKind kind, string version)
         {
-            if(kind == ArtifactKind.PACKAGE)
+            if (kind == ArtifactKind.PACKAGE)
             {
                 return Path.Combine(PackageLocation, version);
             }
-            else if (kind == ArtifactKind.BUNDLE) {
+            else if (kind == ArtifactKind.BUNDLE)
+            {
                 return Path.Combine(BundleLocation, version);
             }
             else

--- a/src/CodeQLToolkit.Shared/CodeQL/RESOLUTION.md
+++ b/src/CodeQLToolkit.Shared/CodeQL/RESOLUTION.md
@@ -27,7 +27,7 @@ list of packs as the packs to include in the bundle.
 Note this will compile all of the queries and may take a long time. In this case, you may create a bundle as follows:
 
 ```
-qlt codeql install --quick-bundle  [--packs pack1 pack2 pack3]
+qlt codeql install --quick-bundle [--packs pack1 pack2 pack3]
 ```
 
 Which will not compile the packs and queries. 
@@ -47,10 +47,17 @@ For a bundle installation the mapping is as follows:
 
 - `CodeQLCLIBundle` - The bundle downloaded from `github/codeql-action/releases` to base the bundle on. 
 
-In all cases, at the end of the execution two to three environment variables are set:
-- `QLT_CODEQL_PATH` - The path to the CodeQL binary. 
-- `QLT_CODEQL_HOME` - The root installation of CodeQL
-- `QLT_CODEQL_BUNDLE_PATH` - The path to the bundle created by QLT.
+In all cases, two environment variables are set after a run:
+- `QLT_CODEQL_PATH` - The path to the CodeQL binary. (Always set)
+- `QLT_CODEQL_HOME` - The root installation of CodeQL. (Always set)
+
+When using custom bundles, four additional environmental variables are set after a run:
+- `QLT_CODEQL_BUNDLE_PATH` - The path to the current platform bundle created by QLT. (Set when using custom bundles)
+- `QLT_CODEQL_BUNDLE_PATH_WIN64` - The path to the Windows bundle created by QLT. (Set when using custom bundles)
+- `QLT_CODEQL_BUNDLE_PATH_LINUX64` - The path to the Linux bundle created by QLT. (Set when using custom bundles)
+- `QLT_CODEQL_BUNDLE_PATH_OSX64` - The path to the MacOS bundle created by QLT. (Set when using custom bundles)
+
+The environmental variable `QLT_CODE_BUNDLE_PATH` will map to one of the three other bundle variables.
 
 ## Idents within the Installation Directory 
 

--- a/src/CodeQLToolkit.Shared/Options/Globals.cs
+++ b/src/CodeQLToolkit.Shared/Options/Globals.cs
@@ -6,27 +6,32 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using CodeQLToolkit.Shared.Types;
- 
+
 namespace CodeQLToolkit.Shared.Options
 {
     public class Globals
     {
-        public static string[] SupportedAutomationTypes { get => new string[] { "actions" }; }
+        public static string[] SupportedAutomationTypes => new string[] { "actions" };
 
-        public static Option<string> BasePathOption { get; } = new Option<string>("--base", () => {
+        public static Option<string> BasePathOption { get; } = new Option<string>("--base", () =>
+        {
             return Directory.GetCurrentDirectory();
         }, "The base path to find the query repository.");
 
-        public static Option<string> AutomationTypeOption { get; } = new Option<string>("--automation-type", () => {
+        public static Option<string> AutomationTypeOption { get; } = new Option<string>("--automation-type", () =>
+        {
             return "actions";
-        }, "The base path to find the query repository.") { IsRequired = true }.FromAmong(SupportedAutomationTypes);
+        }, "The base path to find the query repository.")
+        { IsRequired = true }.FromAmong(SupportedAutomationTypes);
 
-        public static Option<bool> Development { get; } = new Option<bool>("--development", () => {
+        public static Option<bool> Development { get; } = new Option<bool>("--development", () =>
+        {
             return false;
         }, "Turns on development mode which enables special features used in the development of QLT.")
         { IsRequired = true }.FromAmong(SupportedAutomationTypes);
 
-        public static Option<bool> UseBundle { get; } = new Option<bool>("--use-bundle", () => {
+        public static Option<bool> UseBundle { get; } = new Option<bool>("--use-bundle", () =>
+        {
             return false;
         }, "Switching QLT from using the distribution versions of CodeQL to using a Custom Bundle.")
         { IsRequired = true }.FromAmong(SupportedAutomationTypes);

--- a/src/CodeQLToolkit.Shared/Utils/QLTConfig.cs
+++ b/src/CodeQLToolkit.Shared/Utils/QLTConfig.cs
@@ -11,7 +11,7 @@ namespace CodeQLToolkit.Shared.Utils
     {
         public string Name { get; set; }
         public bool Bundle { get; set; }
-        public bool Publish { get; set;}
+        public bool Publish { get; set; }
         public bool ReferencesBundle { get; set; }
 
     }
@@ -24,37 +24,32 @@ namespace CodeQLToolkit.Shared.Utils
         public string CodeQLConfiguration { get; set; }
 
         public CodeQLPackConfiguration[] CodeQLPackConfiguration { get; set; }
-        
-        public string CodeQLStandardLibraryIdent { 
-            get  {
+
+        public string CodeQLStandardLibraryIdent
+        {
+            get
+            {
                 if (CodeQLStandardLibrary != null)
                 {
                     return CodeQLStandardLibrary.Replace("/", "_");
                 }
                 return CodeQLStandardLibrary;
-            } 
+            }
         }
 
         [JsonIgnore]
-        public string CodeQLConfigurationPath { get { return Path.Combine(Base, CodeQLConfiguration); } }
+        public string CodeQLConfigurationPath => Path.Combine(Base, CodeQLConfiguration);
 
         [JsonIgnore]
         public string Base { get; set; }
 
         [JsonIgnore]
-        public string CodeQLConfigFilePath
+        public string QLTConfigFilePath => Path.Combine(Base, "qlt.conf.json");
+
+        public QLTConfig FromFile()
         {
-            get
-            {
-                return Path.Combine(Base, "qlt.conf.json");
-            }
-        }
-
-        public QLTConfig FromFile() {
-            var data = File.ReadAllText(CodeQLConfigFilePath);
+            var data = File.ReadAllText(QLTConfigFilePath);
             QLTConfig c = JsonConvert.DeserializeObject<QLTConfig>(data);
-
-
             c.Base = Base;
             return c;
         }
@@ -62,7 +57,7 @@ namespace CodeQLToolkit.Shared.Utils
         public void ToFile()
         {
             var data = JsonConvert.SerializeObject(this, Formatting.Indented);
-            File.WriteAllText(CodeQLConfigFilePath, data);
+            File.WriteAllText(QLTConfigFilePath, data);
         }
 
         public static QLTConfig? LoadFromFile(string baseDir)
@@ -71,9 +66,9 @@ namespace CodeQLToolkit.Shared.Utils
             {
                 Base = baseDir
             };
-            
 
-            if (File.Exists(config.CodeQLConfigFilePath))
+
+            if (File.Exists(config.QLTConfigFilePath))
             {
                 return config.FromFile();
             }

--- a/src/CodeQLToolkit.Shared/Utils/Query.cs
+++ b/src/CodeQLToolkit.Shared/Utils/Query.cs
@@ -1,4 +1,4 @@
-﻿    using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,97 +14,28 @@ namespace CodeQLToolkit.Shared.Utils
         public string Scope { get; set; }
         public string Name { get; set; }
 
-        public string QuerySrcDir
-        {
-            get
-            {
-                return Path.Combine(Base, Language.ToDirectory(), QueryPackName, "src");
-            }
-        }
+        public string QuerySrcDir => Path.Combine(Base, Language.ToDirectory(), QueryPackName, "src");
 
-        public string QueryFileDir
-        { 
-            get
-            {
-                return Path.Combine(QuerySrcDir, Name);
-            }
-        }
+        public string QueryFileDir => Path.Combine(QuerySrcDir, Name);
 
-        public string QueryFilePath
-        {
-            get
-            {
-                return Path.Combine(QueryFileDir, $"{Name}.ql");
-            }
-        }
+        public string QueryFilePath => Path.Combine(QueryFileDir, $"{Name}.ql");
 
-        public string QueryPackPath
-        {
-            get
-            {
-                return Path.Combine(QuerySrcDir, "qlpack.yml");
-                
-            }
-        }
+        public string QueryPackPath => Path.Combine(QuerySrcDir, "qlpack.yml");
 
         //
-        public string QueryTestDir
-        {
-            get
-            {
-                return Path.Combine(Base, Language.ToDirectory(), QueryPackName, "test");
-            }
-        }
+        public string QueryTestDir => Path.Combine(Base, Language.ToDirectory(), QueryPackName, "test");
 
-        public string QueryFileTestDir
-        {
-            get
-            {
-                return Path.Combine(QueryTestDir, Name);
-            }
-        }
+        public string QueryFileTestDir => Path.Combine(QueryTestDir, Name);
 
-        public string QueryFileTestPath
-        {
-            get
-            {
-                return Path.Combine(QueryFileTestDir, $"{Name}.{Language.ToExtension()}");
-            }
-        }
+        public string QueryFileTestPath => Path.Combine(QueryFileTestDir, $"{Name}.{Language.ToExtension()}");
 
-        public string QueryFileQLRefPath
-        {
-            get
-            {
-                return Path.Combine(QueryFileTestDir, $"{Name}.qlref");
-            }
-        }
+        public string QueryFileQLRefPath => Path.Combine(QueryFileTestDir, $"{Name}.qlref");
 
-        public string QueryPackTestPath
-        {
-            get
-            {
-                return Path.Combine(QueryTestDir, "qlpack.yml");
+        public string QueryPackTestPath => Path.Combine(QueryTestDir, "qlpack.yml");
 
-            }
-        }
+        public string QueryTestExpectedFile => Path.Combine(QueryFileTestDir, $"{Name}.expected");
 
-        public string QueryTestExpectedFile
-        {
-            get
-            {
-                return Path.Combine(QueryFileTestDir, $"{Name}.expected");
-
-            }
-        }
-
-        public string QueryTestPackName
-        {
-            get
-            {
-                return $"{QueryPackName}-tests";
-            }
-        }
+        public string QueryTestPackName => $"{QueryPackName}-tests";
 
         public string GetLanguageImportForLangauge()
         {

--- a/src/CodeQLToolkit.Shared/Utils/ToolUtil.cs
+++ b/src/CodeQLToolkit.Shared/Utils/ToolUtil.cs
@@ -9,14 +9,8 @@ namespace CodeQLToolkit.Shared.Utils
 {
     public class ToolUtil
     {
-        public static string ToolRoot
-        {
-            get
-            {
-                return Path.Combine(Utils.FileUtils.GetExecutingDirectory().FullName, "tools");
-            }
-        }
-        
+        public static string ToolRoot => Path.Combine(Utils.FileUtils.GetExecutingDirectory().FullName, "tools");
+
         public static string ExecutableExtensionForPlatform
         {
             get


### PR DESCRIPTION
Custom bundle creation now uses a platform-independent CodeQL base bundle and creates separate output bundles for Windows, Linux, and MacOS. These bundles are exposed via the `QLT_CODEQL_BUNDLE_PATH_WIN64`, `QLT_CODEQL_BUNDLE_PATH_LINUX64`, and `QLT_CODEQL_BUNDLE_PATH_OSX64` environment variables, with `QLT_CODEQL_BUNDLE_PATH` continuing to map to the bundle compatible with the runner platform.

Additional files/directories or certificates can now be specified in `qlt.conf.json` with the following schema:
```python
        schema = {
            "type": "object",
            "properties": {
                "CodeQLBundleAdditionalFiles": {
                    "type": "array",
                    "items": {
                        "type": "object",
                        "properties": {
                            "Source": {"type": "string"},
                            "Destination": {"type": "string"},
                        },
                        "required": ["Source", "Destination"],
                        "additionalProperties": False,
                    },
                    "minItems": 1,
                },
                "CodeQLBundleAdditionalCertificates": {
                    "type": "array",
                    "items": {
                        "type": "object",
                        "properties": {"Source": {"type": "string"}},
                        "required": ["Source"],
                        "additionalProperties": False,
                    },
                    "minItems": 1,
                },
            },
            "additionalProperties": True,
        }
```