### PR TITLE
Update codeql-bundle tool release download URL

### DIFF
--- a/scripts/build_codeql_bundle_dist.ps1
+++ b/scripts/build_codeql_bundle_dist.ps1
@@ -20,7 +20,7 @@ if (-not (Test-Path $DestinationDirectory)) {
 }
 
 # download a copy of the release from GitHub
-gh release download "v$Version" --repo https://github.com/kraiouchkine/codeql-bundle  -D $WorkDirectory -A zip
+gh release download "v$Version" --repo https://github.com/advanced-security/codeql-bundle  -D $WorkDirectory -A zip
 
 # extract the zip file
 Expand-Archive -Path "$WorkDirectory\codeql-bundle-$Version.zip" -DestinationPath $WorkDirectory


### PR DESCRIPTION
This pull request changes the `scripts/build_codeql_bundle_dist.ps1` file to update the repository URL for downloading the CodeQL bundle release from the now defunct `kraiouchkine/codeql-bundle` repository to our centrally maintained`advanced-security/codeql-bundle`. 