### PR TITLE
Update QLT to use new codeql-bundle tool

### DIFF
--- a/.github/actions/install-qlt-local/action.yml
+++ b/.github/actions/install-qlt-local/action.yml
@@ -60,7 +60,7 @@ runs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.4.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/actions/install-qlt-local/action.yml
+++ b/.github/actions/install-qlt-local/action.yml
@@ -60,7 +60,7 @@ runs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-linux64.yml
+++ b/.github/workflows/internal-build-release-linux64.yml
@@ -69,7 +69,7 @@ jobs:
 
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: qlt-dist
         path: qlt*.zip

--- a/.github/workflows/internal-build-release-linux64.yml
+++ b/.github/workflows/internal-build-release-linux64.yml
@@ -50,7 +50,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.4.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-linux64.yml
+++ b/.github/workflows/internal-build-release-linux64.yml
@@ -50,7 +50,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/linux-x64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-macos64.yml
+++ b/.github/workflows/internal-build-release-macos64.yml
@@ -48,7 +48,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/macos-arm64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/macos-arm64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-macos64.yml
+++ b/.github/workflows/internal-build-release-macos64.yml
@@ -48,7 +48,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/macos-arm64/tools/
+        ./scripts/build_codeql_bundle_dist.ps1 -Version 0.4.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Release/net6.0/publish/macos-arm64/tools/
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-macos64.yml
+++ b/.github/workflows/internal-build-release-macos64.yml
@@ -65,7 +65,7 @@ jobs:
         popd
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: qlt-dist
         path: qlt*.zip

--- a/.github/workflows/internal-build-release-win64.yml
+++ b/.github/workflows/internal-build-release-win64.yml
@@ -45,7 +45,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        .\scripts\build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory .\src\CodeQLToolkit.Core\bin\Release\net6.0\publish\windows-x64\tools\
+        .\scripts\build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory .\src\CodeQLToolkit.Core\bin\Release\net6.0\publish\windows-x64\tools\
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-build-release-win64.yml
+++ b/.github/workflows/internal-build-release-win64.yml
@@ -59,7 +59,7 @@ jobs:
         Pop-Location
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: qlt-dist
         path: qlt*.zip

--- a/.github/workflows/internal-build-release-win64.yml
+++ b/.github/workflows/internal-build-release-win64.yml
@@ -45,7 +45,7 @@ jobs:
         pip install -U pyinstaller 
 
         # run the packaging 
-        .\scripts\build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory .\src\CodeQLToolkit.Core\bin\Release\net6.0\publish\windows-x64\tools\
+        .\scripts\build_codeql_bundle_dist.ps1 -Version 0.4.0 -WorkDirectory dist -DestinationDirectory .\src\CodeQLToolkit.Core\bin\Release\net6.0\publish\windows-x64\tools\
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/internal-pr-build-linux.yml
+++ b/.github/workflows/internal-pr-build-linux.yml
@@ -33,7 +33,7 @@ jobs:
         Compress-Archive -Path .\src\CodeQLToolkit.Core\bin\Release\net6.0\publish\linux-x64\* -DestinationPath qlt-linux-x86_64.zip
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: qlt-dist
         path: qlt*.zip

--- a/.github/workflows/internal-pr-bundle-integration-test-cpp.yml
+++ b/.github/workflows/internal-pr-bundle-integration-test-cpp.yml
@@ -85,7 +85,7 @@ jobs:
         ls -l ${{ steps.analysis.outputs.sarif-output }}
 
     - name: Upload SARIF Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: actual.sarif
         path: |
@@ -93,7 +93,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload Bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: codeql-bundles
         path: |

--- a/.github/workflows/internal-pr-bundle-integration-test-cpp.yml
+++ b/.github/workflows/internal-pr-bundle-integration-test-cpp.yml
@@ -85,7 +85,7 @@ jobs:
         ls -l ${{ steps.analysis.outputs.sarif-output }}
 
     - name: Upload SARIF Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: actual.sarif
         path: |
@@ -93,7 +93,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload Bundles
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: codeql-bundles
         path: |

--- a/.github/workflows/run-bundle-integration-tests-cpp.yml
+++ b/.github/workflows/run-bundle-integration-tests-cpp.yml
@@ -65,7 +65,7 @@ jobs:
         ls -l ${{ env.QLT_CODEQL_HOME }}/../out/
 
     - name: Upload Bundles
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: codeql-bundles
         path: |
@@ -102,7 +102,7 @@ jobs:
         ls -l ${{ steps.analysis.outputs.sarif-output }}
 
     - name: Upload SARIF Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: actual.sarif
         path: |

--- a/.github/workflows/run-bundle-integration-tests-cpp.yml
+++ b/.github/workflows/run-bundle-integration-tests-cpp.yml
@@ -65,7 +65,7 @@ jobs:
         ls -l ${{ env.QLT_CODEQL_HOME }}/../out/
 
     - name: Upload Bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: codeql-bundles
         path: |
@@ -102,7 +102,7 @@ jobs:
         ls -l ${{ steps.analysis.outputs.sarif-output }}
 
     - name: Upload SARIF Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: actual.sarif
         path: |

--- a/.github/workflows/run-codeql-unit-tests-cpp.yml
+++ b/.github/workflows/run-codeql-unit-tests-cpp.yml
@@ -106,7 +106,7 @@ jobs:
 
             
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ runner.os }}-${{ matrix.codeql_cli }}-${{ matrix.codeql_standard_library_ident }}
           path: |

--- a/.github/workflows/run-codeql-unit-tests-cpp.yml
+++ b/.github/workflows/run-codeql-unit-tests-cpp.yml
@@ -132,7 +132,7 @@ jobs:
 
 
       - name: Collect test results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
 
       - name: Validate test results
         run: |

--- a/.github/workflows/run-codeql-unit-tests-cpp.yml
+++ b/.github/workflows/run-codeql-unit-tests-cpp.yml
@@ -106,7 +106,7 @@ jobs:
 
             
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ runner.os }}-${{ matrix.codeql_cli }}-${{ matrix.codeql_standard_library_ident }}
           path: |

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -15,7 +15,7 @@ Note that we keep recent copies of tools (for local debugging purposes) in the `
 **CodeQL Bundle**
 
 ```
-./scripts/build_codeql_bundle_dist.ps1 -Version 0.3.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Debug/net6.0/tools
+./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Debug/net6.0/tools
 ```
 
 

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -15,7 +15,7 @@ Note that we keep recent copies of tools (for local debugging purposes) in the `
 **CodeQL Bundle**
 
 ```
-./scripts/build_codeql_bundle_dist.ps1 -Version 0.2.1 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Debug/net6.0/tools
+./scripts/build_codeql_bundle_dist.ps1 -Version 0.4.0 -WorkDirectory dist -DestinationDirectory ./src/CodeQLToolkit.Core/bin/Debug/net6.0/tools
 ```
 
 

--- a/scripts/build_codeql_bundle_dist.ps1
+++ b/scripts/build_codeql_bundle_dist.ps1
@@ -32,6 +32,7 @@ Push-Location $ArchiveDirectory
 
 # at this point python should already be installed as well as poetry
 # export the requirements 
+poetry self add poetry-plugin-export
 poetry export -f requirements.txt > requirements.txt
 
 # install the requirements

--- a/scripts/build_codeql_bundle_dist.ps1
+++ b/scripts/build_codeql_bundle_dist.ps1
@@ -1,15 +1,16 @@
 param(
     [Parameter(Mandatory = $true)] 
-    [string]
-    $Version,
-    [Parameter(Mandatory = $true)] 
-    [string]
-    $WorkDirectory,      
+    [string] $Version,
 
     [Parameter(Mandatory = $true)] 
-    [string]
-    $DestinationDirectory       
+    [string] $WorkDirectory,      
+
+    [Parameter(Mandatory = $true)] 
+    [string] $DestinationDirectory       
 )
+
+# Fail on any built-in command failure
+$ErrorActionPreference = "Stop"
 
 if (-not (Test-Path $WorkDirectory)) {
     New-Item -ItemType Directory -Path $WorkDirectory | Out-Null
@@ -19,33 +20,50 @@ if (-not (Test-Path $DestinationDirectory)) {
     New-Item -ItemType Directory -Path $DestinationDirectory | Out-Null
 }
 
-# download a copy of the release from GitHub
-gh release download "v$Version" --repo https://github.com/advanced-security/codeql-bundle  -D $WorkDirectory -A zip
+# Download a copy of the release from GitHub
+gh release download "v$Version" --repo https://github.com/advanced-security/codeql-bundle -D $WorkDirectory -A zip
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to download release from GitHub (gh)"
+}
 
-# extract the zip file
+# Extract the zip file
 Expand-Archive -Path "$WorkDirectory\codeql-bundle-$Version.zip" -DestinationPath $WorkDirectory
 
-# creates a directory named `codeql-bundle-<version>`
+# Create path to archive directory (named codeql-bundle-<version>)
 $ArchiveDirectory = Join-Path $WorkDirectory "codeql-bundle-$Version"
 
 Push-Location $ArchiveDirectory
 
-# at this point python should already be installed as well as poetry
-# export the requirements 
+# Export the requirements using poetry
 poetry self add poetry-plugin-export
-poetry export -f requirements.txt > requirements.txt
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to add poetry-plugin-export"
+}
 
-# install the requirements
+poetry export -f requirements.txt --output requirements.txt
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to export requirements using poetry"
+}
+
+# Install the requirements using pip
 pip install -r requirements.txt
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to install requirements using pip"
+}
 
+# Move into the cli directory
 Push-Location "codeql_bundle"
 
-# pyinstaller should also be installed  
+# Build executable with pyinstaller
 pyinstaller -F -n codeql_bundle cli.py
+if ($LASTEXITCODE -ne 0) {
+    throw "PyInstaller build failed"
+}
 
-Pop-Location 
-Pop-Location 
+Pop-Location
+Pop-Location
 
+# Determine built output binary path
 if ($IsWindows) {
     $OutputFile = Join-Path $ArchiveDirectory "codeql_bundle" "dist" "codeql_bundle.exe"
 }
@@ -53,8 +71,5 @@ else {
     $OutputFile = Join-Path $ArchiveDirectory "codeql_bundle" "dist" "codeql_bundle"
 }
 
-
-# this will output the binary in the `dist` directory - we should copy that binary the toplevel directory.
+# Copy the binary to the destination directory
 Copy-Item -Path $OutputFile -Destination $DestinationDirectory
-
-

--- a/scripts/build_codeql_bundle_dist.ps1
+++ b/scripts/build_codeql_bundle_dist.ps1
@@ -20,7 +20,7 @@ if (-not (Test-Path $DestinationDirectory)) {
 }
 
 # download a copy of the release from GitHub
-gh release download "v$Version" --repo https://github.com/kraiouchkine/codeql-bundle  -D $WorkDirectory -A zip
+gh release download "v$Version" --repo https://github.com/advanced-security/codeql-bundle  -D $WorkDirectory -A zip
 
 # extract the zip file
 Expand-Archive -Path "$WorkDirectory\codeql-bundle-$Version.zip" -DestinationPath $WorkDirectory

--- a/src/CodeQLToolkit.Features/Templates/Bundle/Actions/run-bundle-integration-tests.liquid
+++ b/src/CodeQLToolkit.Features/Templates/Bundle/Actions/run-bundle-integration-tests.liquid
@@ -86,7 +86,7 @@ jobs:
         ls -l ${{ env.QLT_CODEQL_HOME }}/../out/
 
     - name: Upload Bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: codeql-bundles
         path: |
@@ -130,7 +130,7 @@ jobs:
         ls -l ${{ steps.analysis.outputs.sarif-output }}
 
     - name: Upload SARIF Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: actual.sarif
         path: |

--- a/src/CodeQLToolkit.Features/Templates/Bundle/Actions/run-bundle-integration-tests.liquid
+++ b/src/CodeQLToolkit.Features/Templates/Bundle/Actions/run-bundle-integration-tests.liquid
@@ -86,7 +86,7 @@ jobs:
         ls -l ${{ env.QLT_CODEQL_HOME }}/../out/
 
     - name: Upload Bundles
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: codeql-bundles
         path: |
@@ -130,7 +130,7 @@ jobs:
         ls -l ${{ steps.analysis.outputs.sarif-output }}
 
     - name: Upload SARIF Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: actual.sarif
         path: |

--- a/src/CodeQLToolkit.Features/Templates/Test/Actions/run-unit-tests.liquid
+++ b/src/CodeQLToolkit.Features/Templates/Test/Actions/run-unit-tests.liquid
@@ -137,7 +137,7 @@ jobs:
 {% endif %}
 {% raw %}            
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ runner.os }}-${{ matrix.codeql_cli }}-${{ matrix.codeql_standard_library_ident }}
           path: |

--- a/src/CodeQLToolkit.Features/Templates/Test/Actions/run-unit-tests.liquid
+++ b/src/CodeQLToolkit.Features/Templates/Test/Actions/run-unit-tests.liquid
@@ -137,7 +137,7 @@ jobs:
 {% endif %}
 {% raw %}            
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ runner.os }}-${{ matrix.codeql_cli }}-${{ matrix.codeql_standard_library_ident }}
           path: |

--- a/src/CodeQLToolkit.Features/Templates/Test/Actions/run-unit-tests.liquid
+++ b/src/CodeQLToolkit.Features/Templates/Test/Actions/run-unit-tests.liquid
@@ -170,7 +170,7 @@ jobs:
 {% endif %}
 {% raw %}
       - name: Collect test results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
 
       - name: Validate test results
         run: |


### PR DESCRIPTION
- Update all calls to the `build_codeql_bundle_dist.ps1` script to point to version 0.2.11 (project-wide `s/0.3.0/0.2.1/`)
- Update the name from `kraiouchkine` to `advanced-security` (project-wide `s/kraiouchkine/advanced-security/`)
- Use `actions/upload-artifact@v4` instead of `v2`